### PR TITLE
34 missing additional property value while tranfering extended information independently

### DIFF
--- a/AVAL-Spec.yml
+++ b/AVAL-Spec.yml
@@ -398,6 +398,12 @@ paths:
           required: true
           type: "string"
           format: "uuid"
+        - name: "transactionId"
+          in: "path"
+          description: "ID of AvaL Transaction which should be updated"
+          required: true
+          type: "string"
+          format: "uuid"
         - in: "body"
           name: "body"
           description: "Extended Information in the form of an AdditionalContent object."
@@ -599,7 +605,7 @@ definitions:
         description: "document types as defined in AvalDocuments/documentType; those documents must be made available before the transaction state goes to 9"
         example: [ "AD.1.1.101", "AD.1.9.901"]
         items:
-          type: "string"          
+          type: "string"
       requiredDeviationDocuments:
         type: "array"
         description: "document types as defined in AvalDocuments/documentType; those documents must be made available before the transaction state goes to 10"

--- a/AVAL-Spec.yml
+++ b/AVAL-Spec.yml
@@ -28,7 +28,7 @@ info:
     * [Contact form](https://www.avalstandard.de/kontaktformular)
     * [Contact persons](https://www.avalstandard.de/kontakt/ansprechpartner)
 
-  version: "1.0.0"
+  version: "1.0.1"
   title: "AvaL API specification"
   termsOfService: "https://www.avalstandard.de/impressum"
   contact:
@@ -130,7 +130,9 @@ paths:
           description: "Extended Information in the form of an AdditionalContent object."
           required: true
           schema:
-            $ref: "#/definitions/AdditionalContent"
+            type: object
+            additionalProperties:
+              $ref: "#/definitions/AdditionalContent"
       responses:
         200:
           description: "Successful operation."
@@ -240,7 +242,9 @@ paths:
           description: "Extended Information in the form of an AdditionalContent object."
           required: true
           schema:
-            $ref: "#/definitions/AdditionalContent"
+            type: object
+            additionalProperties:
+              $ref: "#/definitions/AdditionalContent"
       responses:
         200:
           description: "Successful operation."
@@ -399,7 +403,9 @@ paths:
           description: "Extended Information in the form of an AdditionalContent object."
           required: true
           schema:
-            $ref: "#/definitions/AdditionalContent"
+            type: object
+            additionalProperties:
+              $ref: "#/definitions/AdditionalContent"
       responses:
         200:
           description: "Successful operation."


### PR DESCRIPTION
Use the same data structure for ExtendInformation as in matching or transaction updates

![image](https://github.com/Entwicklung-AvaL-Standard/aval-api-spec/assets/9478033/6d09c3ee-a4c2-4cda-999c-25de8b9adcf4)