### PR TITLE
Fix: Uniform use of camel case instead of kebab case

### DIFF
--- a/AVAL-Spec.yml
+++ b/AVAL-Spec.yml
@@ -27,7 +27,7 @@ info:
     Contact:
     * [Contact form](https://www.avalstandard.de/kontaktformular)
     * [Contact persons](https://www.avalstandard.de/kontakt/ansprechpartner)
-version: "1.7.0"
+  version: "1.7.1"
   title: "AvaL API specification"
   termsOfService: "https://www.avalstandard.de/impressum"
   contact:
@@ -483,7 +483,7 @@ paths:
           description: "AvaL Transaction not found."
         500:
           description: "An unexpected error occurred. Details may be included within the response body."
-  /avalmatchings/{avalId}/avaltransactions/{transactionId}/cancellation-request:
+  /avalmatchings/{avalId}/avaltransactions/{transactionId}/cancellationRequest:
     post:
       tags:
         - "AvaL Transactions"


### PR DESCRIPTION
With the introduction of the Cancellation Request, Kebab Case was mistakenly used for the URI. The AvaL Spec currently uses a mix of Camel Case and All Lower Case. Therefore, Kebab Case should be replaced with Camel Case (see ExtendedInformation).

In the future, the casing should be standardized across the entire API. However, this requires a separate ticket to be created, and any breaking changes must be discussed beforehand.